### PR TITLE
Prepare new release 1.0.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,11 @@ jobs:
           yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
           yum localinstall -y bdii-config-site-*.el7.noarch.rpm
 
-  # Dependency from PowerTools: openldap-servers
+  # FIXME: openldap-servers is in CentOS 8 Stream Powertools, but not in AlmaLinux PowerTools
+  # See https://bugs.almalinux.org/view.php?id=222
+  # Currently instaling using the package from devel repository
+  # See https://bugs.almalinux.org/view.php?id=100
+  # https://repo.almalinux.org/almalinux/8/devel/x86_64/os/Packages/
   # FIXME: will fail until UMD for RHEL 8 is available
   almalinux8-install:
     name: Install AlmaLinux 8 RPMs
@@ -83,7 +87,7 @@ jobs:
           name: rpms8
       - name: Install generated RPMs
         run: |
-          sed -i 's/^enabled=0/enabled=1/' /etc/yum.repos.d/almalinux-powertools.repo
+          yum install -y https://repo.almalinux.org/almalinux/8/devel/x86_64/os/Packages/openldap-servers-2.4.46-18.el8.x86_64.rpm
           yum localinstall -y bdii-config-site-*.el8.noarch.rpm
 
   # XXX Dependencies from EPEL: openldap-servers

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,3 +7,52 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.8] - 2023-03-16
+
+### Added
+
+- Update source URL information, package additional documentation. (#3) (Baptiste Grenier)
+
+## [1.0.7] - 2013-04-24
+
+### Fixed
+
+- Fixed rpmlint errors: Changed /opt/glite/libexec to /usr/libexec (#98427) (Maria Alandes)
+
+## [1.0.6] - 2013-04-14
+
+### Changed
+
+- Improved dependency definition (Laurence Field)
+
+## [1.0.5] - 2012-08-22
+
+### Fixed
+
+- Fixed (#84241) (Laurence Field)
+
+## [1.0.3] - 2011-04-18
+
+### Changed
+
+- Removed dependency on glite-info-provider-release (Laurence Field)
+
+
+## [1.0.2] - 2011-04-05
+
+### Fixed
+
+- Fixed error due to new version of glite-info-provider-service (Laurence Field)
+
+## [1.0.1] - 2011-03-21
+
+### Changed
+
+- Changed config location to /etc/bdii/gip (Laurence Field)
+
+## [1.0.0] - 2011-03-15
+
+### Fixed
+
+- Fixed Is-148 (Laurence Field)

--- a/bdii-config-site.spec
+++ b/bdii-config-site.spec
@@ -1,6 +1,6 @@
 Name:          bdii-config-site
-Version:       1.0.7
-Release:       2%{?dist}
+Version:       1.0.8
+Release:       1%{?dist}
 Summary:       Site BDII configuration files
 Group:         Development/Libraries
 License:       ASL 2.0
@@ -48,6 +48,9 @@ rm -rf %{buildroot}
 %license /usr/share/licenses/%{name}-%{version}/LICENSE.txt
 
 %changelog
+* Thu Mar 16 2023 Baptiste Grenier <baptiste.grenier@egi.eu> - 1.0.8-1
+- Update source URL information, package additional documentation. (#3) (Baptiste Grenier)
+
 * Wed Apr 24 2013 Maria Alandes <maria.alandes.pradillo@cern.ch> - 1.0.7-2
 - Added Source URL information
 


### PR DESCRIPTION
Prepare new release 1.0.8:
- Update source URL information, package additional documentation. (#3) (Baptiste Grenier)